### PR TITLE
Cmake MSVC improvements (#13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 headers/libBeaEngine.so
 **.pyc
 lib
+bin
 build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,13 +121,21 @@ if (BEA_COMPILER STREQUAL msvc)
 		set (BEA_WARNINGS /W4)
 	endif ()
   endif ()
-  if (optHAS_SYMBOLS)
-    list (APPEND BEA_FLAGS /ZI)
-	list (APPEND BEA_DEFINITIONS "/D_DEBUG=1")
-  endif ()
+
+  list (APPEND BEA_FLAGS /Zi)
+
   if (optHAS_OPTIMIZED)
     list (APPEND BEA_FLAGS /O2)
     list (APPEND BEA_DEFINITIONS "/DNDEBUG")
+  else ()
+    list (APPEND BEA_DEFINITIONS "/D_DEBUG")
+  endif ()
+
+  #generate PDB for Debug/RelWithDebInfo builds
+  if (optHAS_SYMBOLS)
+    if (optBUILD_DLL)
+      set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG /OPT:REF,ICF")
+    endif ()
   endif ()
 
   # determine code generation model
@@ -306,7 +314,6 @@ if (${CMAKE_BUILD_TYPE} STREQUAL Debug)
   set (CMAKE_CXX_FLAGS_DEBUG ${myCXX_FLAGS})
 endif ()
 
-
 set (BEA_INCLUDE_PATH ${CMAKE_SOURCE_DIR}/include)
 set (BEA_SRC_ROOT ${CMAKE_SOURCE_DIR}/src)
 
@@ -365,6 +372,10 @@ endif ()
 
 if (NOT optHAS_OPTIMIZED)
   set (BEA_TARGET "${BEA_TARGET}_d")
+endif ()
+
+if (NOT optBUILD_LITE)
+  set (BEA_TARGET "${BEA_TARGET}_l")
 endif ()
 
 if (optBUILD_STDCALL)


### PR DESCRIPTION
* Add library suffix for lite version.

* _DEBUG define doesn't apply when optHAS_OPTIMIZED is OFF. On the other side optHAS_SYMBOLS is not correlate with _DEBUG define.

* Fix .gitignore

* Redesign PDB generation for DLLs. Disable it for static libraries.